### PR TITLE
fix handleSeccomp ptrace stack overrun

### DIFF
--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -381,7 +381,7 @@ void execution::handleExecve(const pid_t traceesPid){
 // =======================================================================================
 bool execution::handleSeccomp(const pid_t traceesPid){
   // Fetch system call provided to us via seccomp.
-  uint16_t syscallNum;
+  long syscallNum;
   ptracer::doPtrace(PTRACE_GETEVENTMSG, traceesPid, nullptr, &syscallNum);
 
   // INT16_MAX is sent by seccomp by convention as for system calls with no


### PR DESCRIPTION
382 bool execution::handleSeccomp(const pid_t traceesPid){
383   // Fetch system call provided to us via seccomp.
384   int16_t syscallNum;

`int16_t` should changed to `long`, otherwise it can cause stack overrun because `ptrace` syscall assume `data` is a pointer (64-bit in amd64). It can cause `traceesPid` (or other stack frame) corruption due to `int16_t` is only 16-bit wide.
