### PR TITLE
Add BUILD=release option to toggle -O3

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,10 @@
+BUILD=debug
 CXX = clang++
 CC= clang
 
-DEBUG =  -O0 -g
-CXXFLAGS = $(DEBUG) -std=c++14 -Wall $(INCLUDE)
+cxxflags.debug   = -O0 -g
+cxxflags.release = -O3 -g
+CXXFLAGS = ${cxxflags.${BUILD}} -std=c++14 -Wall $(INCLUDE)
 CFLAGS = $(DEBUG) -Wall -Wshadow $(INCLUDE)
 LIBS = -pthread -lseccomp -L ../lib/lib64
 

--- a/test/unitTests/Makefile
+++ b/test/unitTests/Makefile
@@ -1,6 +1,8 @@
+BUILD=debug
 CXX = clang++
-DEBUG =  -O0 -g
-CXXFLAGS = $(DEBUG) -std=c++14 -Wall $(INCLUDE)
+cxxflags.debug   = -O0 -g
+cxxflags.release = -O3 -g
+CXXFLAGS = ${cxxflags.${BUILD}} -std=c++14 -Wall $(INCLUDE)
 
 src = $(wildcard *.cpp)
 obj = $(src:.cpp=.o)

--- a/test/unitTests/otherClassesTests/Makefile
+++ b/test/unitTests/otherClassesTests/Makefile
@@ -1,6 +1,8 @@
+BUILD=debug
 CXX = g++
-DEBUG =  -O0 -g
-CXXFLAGS = $(DEBUG) -std=c++14 -Wall $(INCLUDE)
+cxxflags.debug   = -O0 -g
+cxxflags.release = -O3 -g
+CXXFLAGS = ${cxxflags.${BUILD}} -std=c++14 -Wall $(INCLUDE)
 
 src = $(wildcard *.cpp)
 obj = $(src:.cpp=.o)


### PR DESCRIPTION
To use this, simply append `BUILD=release` next to the `make` target you want (e.g., `make test BUILD=release`).