### PR TITLE
fix some DetTrace unreproducible builds

### DIFF
--- a/src/dettraceSystemCall.cpp
+++ b/src/dettraceSystemCall.cpp
@@ -892,8 +892,12 @@ void recvmsgSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t,
 // =======================================================================================
 bool renameSystemCall::handleDetPre(globalState& gs, state& s, ptracer& t,
                                     scheduler& sched){
-  // Turn into a newfstatat system call to see if oldpath existed. If so, we must mark
-  // all path as deleted.
+  gs.log.writeToLog(Importance::info, "rename pre-hook, s.firstTrySystemcall:%d\n", s.firstTrySystemcall);
+  printInfoString(t.arg1(), gs, s, " old path: ");
+  printInfoString(t.arg2(), gs, s, " new path: ");
+
+  // Turn into a newfstatat system call to see if newpath exists. If so, we must mark
+  // newpath as deleted.
   bool ret = injectNewfstatatIfNeeded(gs, s, t, AT_FDCWD, (char*) t.arg2());
   if(ret){
     // We have work to do in the newfstatat post hook! Make sure to intercept this, hence,
@@ -901,8 +905,6 @@ bool renameSystemCall::handleDetPre(globalState& gs, state& s, ptracer& t,
     return true;
   }
 
-  printInfoString(t.arg1(), gs, s, " renaming-ing path: ");
-  printInfoString(t.arg2(), gs, s, " to path: ");
   // We must go into the post hook to delete the inode.
   return true;
 }
@@ -912,8 +914,8 @@ void renameSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t,
   if((int) t.getReturnValue() >= 0){
     removeInodeFromMaps(s.inodeToDelete, gs, t);
     s.inodeToDelete = -1;
-    s.firstTrySystemcall = true;
   }
+  s.firstTrySystemcall = true;
 
   return;
 }
@@ -942,8 +944,8 @@ void renameatSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t,
   if((int) t.getReturnValue() >= 0){
     removeInodeFromMaps(s.inodeToDelete, gs, t);
     s.inodeToDelete = -1;
-    s.firstTrySystemcall = true;
   }
+  s.firstTrySystemcall = true;
 }
 // =======================================================================================
 bool renameat2SystemCall::handleDetPre(globalState& gs, state& s, ptracer& t,
@@ -978,8 +980,8 @@ void renameat2SystemCall::handleDetPost(globalState& gs, state& s, ptracer& t,
   if((int) t.getReturnValue() >= 0){
     removeInodeFromMaps(s.inodeToDelete, gs, t);
     s.inodeToDelete = -1;
-    s.firstTrySystemcall = true;
   }
+  s.firstTrySystemcall = true;
 }
 // =======================================================================================
 bool rmdirSystemCall::handleDetPre(globalState& gs, state& s, ptracer& t, scheduler& sched){
@@ -1004,8 +1006,8 @@ void rmdirSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t, sched
   if((int) t.getReturnValue() >= 0){
     removeInodeFromMaps(s.inodeToDelete, gs, t);
     s.inodeToDelete = -1;
-    s.firstTrySystemcall = true;
   }
+  s.firstTrySystemcall = true;
 }
 // =======================================================================================
 // cribbed from strace, as using the standard struct sigaction does not yield
@@ -1510,8 +1512,9 @@ unlinkSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t, scheduler
    // Not our first time. This is after the real unlink actually happened.
   if((int) t.getReturnValue() >= 0){
     removeInodeFromMaps(s.inodeToDelete, gs, t);
-    s.firstTrySystemcall = true;
+    s.inodeToDelete = -1;
   }
+  s.firstTrySystemcall = true;
 
   return;
 }
@@ -2070,6 +2073,9 @@ bool injectNewfstatatIfNeeded(globalState& gs, state& s, ptracer& t, int dirfd,
  * Only delete if exists, not existing is not an error.
  */
 void removeInodeFromMaps(ino_t inode, globalState& gs, ptracer& t){
+
+  gs.log.writeToLog(Importance::extra, "Attempting to remove inode %d from maps...\n", inode);
+  
   // Nothing to do.
   if(inode == -1){
     return;


### PR DESCRIPTION
Resolve issues with inode recycling by injecting `fstat[at]` more thoroughly upon `rename`, `unlink`, and other syscalls that cause a file to be deleted. This helps us keep the inode/mtime maps up to date.

With the `bicyclerepair` package we didn't inject an `fstat` for the overwritten file _of_, so we kept its inode _ofin_ in our maps even though it was freed by the filesystem. Later, if the filesystem recycled this inode for a new file _nf_, we treated its mtime like that of the _of_. If the filesystem did **not** recycle _ofin_ then we allocated a new mtime for _nf_. This caused occasional irreproducibility.

I tested this patch by building `aafigure`, `agtl` and `bicyclerepair` 20 times each (I chose these since they build in ~5 minutes). Without this patch, there were 18/20, 11/20, 7/20 unreproducible builds, respectively. With this patch, all 60 builds are reproducible.

@gatoWololo please take a look and see if I am using `state::firstTrySystemcall` correctly, and the other little changes.