### PR TITLE
Fixed issue with removing processes from scheduler

### DIFF
--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -71,19 +71,28 @@ public:
   void addAndScheduleNext(pid_t newProcess);
 
   /**
-   * Removes process at the top of the heap and schedules new process to run.
+   * Remove a process from the scheduler when it is not at the top of the 
+   * runnableHeap or the blockedHeap.
+   * @param process pid of process to be removed
+   */ 
+  void removeNotTop(pid_t process);
+
+  /**
+   * Removes process and schedules new process to run.
+   * @param process to remove
    * @return return true if we're all done with all processes in the scheduler.
    * This marks the end of the program.
    */
-  bool removeAndScheduleNext();
+  bool removeAndScheduleNext(pid_t process);
 
   /**
    * Removes specified process, let our parent run to completion.
    * Should only be called by the last child of parent, when parent has already
    * been marked as finished.
-   * @param parent pid of parent process
+   * @param pid of process to remove from scheduler
+   * @param pid of parent process
    */
-  void removeAndScheduleParent(pid_t parent);
+  void removeAndScheduleParent(pid_t child, pid_t parent);
 
   /**
    * Find and erase process from scheduler's process tree.
@@ -151,8 +160,9 @@ private:
    * @see deleteProcess
    * @see removeAndScheduleNext
    * @see removeAndScheduleParent
+   * @param process to remove from scheduler
    */
-  void remove();
+  void remove(pid_t process);
 
   /**
    * Get next process based on whether the runnableHeap is empty.

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -52,13 +52,13 @@ bool execution::handleExit(const pid_t traceesPid){
      myScheduler.isFinished(parent) &&       // Check if our parent is marked as finished.
      processTree.count(parent) == 0){        // Parent has no children left.
     
-    myScheduler.removeAndScheduleParent(parent);
+    myScheduler.removeAndScheduleParent(traceesPid, parent);
     return false;
   }
   // Generic case, should happen most of the time.
   else{
     // Process done, schedule next process to run.
-    bool empty = myScheduler.removeAndScheduleNext();
+    bool empty = myScheduler.removeAndScheduleNext(traceesPid);
     if(empty){
       // All processes have finished! We're done
       return true;

--- a/test/samplePrograms/ExpectedOutputs/deadlockingPipe.output
+++ b/test/samplePrograms/ExpectedOutputs/deadlockingPipe.output
@@ -1,4 +1,4 @@
 terminate called after throwing an instance of 'std::runtime_error'
-  what():  dettrace runtime exception: No runnable processes left in scheduler!
+  what():  dettrace runtime exception: Deadlock detected!
 
 Aborted (core dumped)


### PR DESCRIPTION
Fixed a bug in the scheduler where the process being removed was not always at the top of the runnable heap. Also changed the output for when a deadlock occurs so that it is more obvious.