### PR TITLE
No more C++17 needed.

### DIFF
--- a/include/utilSystemCalls.hpp
+++ b/include/utilSystemCalls.hpp
@@ -67,11 +67,11 @@ ino_t readInodeFor(logger& log, pid_t traceePid, int fd);
  * Properly handles relative paths (cwd), and chroots, to reach correct file from the
  * tracee's point of view.
  * Uses traceeDirFd to mimic semantics of *at symstem calls, e.g. mkdirat. See man 2 mkdirat
- * for specific semantics.
+ * for specific semantics. Use value -1 as poor man's optional type NONE.
  * Assumes that `traceeDirFd` is currently open for traceePid.
  */
 ino_t inode_from_tracee(string traceePath, pid_t traceePid, logger& log,
-                        optional<int> traceeDirFd);
+                        int traceeDirFd);
 
 /**
  *
@@ -129,20 +129,20 @@ bool sendTraceeSignalNow(int signum, globalState& gs, state& s, ptracer& t,
  * resolve path. Takes optional dirfd argument, for tracee calls using *at.
  */
 string resolve_tracee_path(string traceePath, pid_t traceePid, logger& log,
-                           optional<int> traceeDirFd);
+                           int traceeDirFd);
 
 /**
  * Check if a file relative to a tracee exists. Calls resolve_tracee_path,
  * uses stat on file to emulate behavior of open() and openat().
  */
 bool tracee_file_exists(string traceePath, pid_t traceePid, logger& log,
-                        optional<int> traceeDirFd);
+                        int traceeDirFd);
 /**
  * Handler for open and openat. Checks if the file exists and sets s.fileExisted,
  * if O_CREAT was set. This way we know whether a new file was created if the system
  * call suceeds.
  */
-void handlePreOpens(globalState& gs, state& s, ptracer& t, optional<int> dirfd,
+void handlePreOpens(globalState& gs, state& s, ptracer& t, int dirfd,
                     traceePtr<char> charpath, int flags);
 /**
  * Handler for open and openat. Checks if the file previously existed, if it didn't

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ CC= clang
 
 DEFINES=-D_GNU_SOURCE=1 -D_POSIX_C_SOURCE=20181101 -D__USE_XOPEN=1
 
-CXXFLAGS =-g -O0 -std=c++17 -Wall $(INCLUDE) $(DEFINES)
+CXXFLAGS =-g -O0 -std=c++14 -Wall $(INCLUDE) $(DEFINES)
 CFLAGS =-g -O0 -Wall -Wshadow $(INCLUDE) $(DEFINES)
 LIBS = -pthread -lseccomp -L ../lib/lib64
 

--- a/src/dettraceSystemCall.cpp
+++ b/src/dettraceSystemCall.cpp
@@ -755,7 +755,7 @@ void mkdirSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t,
   // Add/overwrite entry in our map.
   if(t.getReturnValue() == 0 && (char*) t.arg1() != nullptr){
     string strPath = t.readTraceeCString(traceePtr<char>((char*) t.arg1()), s.traceePid);
-    auto inode = inode_from_tracee(strPath, s.traceePid, gs.log, nullopt);
+    auto inode = inode_from_tracee(strPath, s.traceePid, gs.log, -1);
     gs.mtimeMap.addRealValue(inode);
   }
 }
@@ -857,7 +857,7 @@ void linkatSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t,
 // =======================================================================================
 bool openSystemCall::handleDetPre(globalState& gs, state& s, ptracer& t, scheduler& sched){
   if((char*) t.arg1() != nullptr){
-    handlePreOpens(gs, s, t, nullopt, traceePtr<char>{(char*) t.arg1()}, t.arg2());
+    handlePreOpens(gs, s, t, -1, traceePtr<char>{(char*) t.arg1()}, t.arg2());
     return true;
   }
   return false;
@@ -1462,7 +1462,7 @@ bool symlinkSystemCall::handleDetPre(globalState& gs, state& s, ptracer& t, sche
 void symlinkSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t, scheduler& sched){
   if(t.getReturnValue() == 0 && (char*) t.arg2() != nullptr){
     string linkpath = t.readTraceeCString(traceePtr<char>((char*) t.arg2()), s.traceePid);
-    auto inode = inode_from_tracee(linkpath, s.traceePid, gs.log, nullopt);
+    auto inode = inode_from_tracee(linkpath, s.traceePid, gs.log, -1);
     gs.mtimeMap.addRealValue(inode);
   }
 }
@@ -1494,7 +1494,7 @@ void mknodSystemCall::
 handleDetPost(globalState& gs, state& s, ptracer& t, scheduler& sched){
   if(t.getReturnValue() == 0 && (char*) t.arg1() != nullptr){
     string path = t.readTraceeCString(traceePtr<char>((char*) t.arg1()), s.traceePid);
-    auto inode = inode_from_tracee(path, s.traceePid, gs.log, nullopt);
+    auto inode = inode_from_tracee(path, s.traceePid, gs.log, -1);
     gs.mtimeMap.addRealValue(inode);
   }
 }


### PR DESCRIPTION
We no longer rely on C++17 features. This makes it easier to compile dettrace in older systems e.g. Wheezy VM.