### PR TITLE
allocate virtual inodes whenever new filesystem object is created

### DIFF
--- a/src/dettraceSystemCall.cpp
+++ b/src/dettraceSystemCall.cpp
@@ -194,7 +194,8 @@ void creatSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t, sched
   // safe. (Not sure how we could use this information to optimze anyways.)
   auto inode = readInodeFor(gs.log, s.traceePid, t.getReturnValue());
   gs.mtimeMap.addRealValue(inode);
-
+  gs.inodeMap.addRealValue(inode);
+  
   return;
 }
 // =======================================================================================
@@ -820,6 +821,7 @@ void mkdirSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t,
     string strPath = t.readTraceeCString(traceePtr<char>((char*) t.arg1()), s.traceePid);
     auto inode = inode_from_tracee(strPath, s.traceePid, gs.log, -1);
     gs.mtimeMap.addRealValue(inode);
+    gs.inodeMap.addRealValue(inode);
   }
 }
 // =======================================================================================
@@ -838,6 +840,7 @@ void mkdiratSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t,
     string strPath = t.readTraceeCString(traceePtr<char>(path), s.traceePid);
     auto inode = inode_from_tracee(strPath, s.traceePid, gs.log, t.arg1());
     gs.mtimeMap.addRealValue(inode);
+    gs.inodeMap.addRealValue(inode);
   }
 }
 // =======================================================================================
@@ -1527,6 +1530,7 @@ void symlinkSystemCall::handleDetPost(globalState& gs, state& s, ptracer& t, sch
     string linkpath = t.readTraceeCString(traceePtr<char>((char*) t.arg2()), s.traceePid);
     auto inode = inode_from_tracee(linkpath, s.traceePid, gs.log, -1);
     gs.mtimeMap.addRealValue(inode);
+    gs.inodeMap.addRealValue(inode);
   }
 }
 // =======================================================================================
@@ -1544,6 +1548,7 @@ handleDetPost(globalState& gs, state& s, ptracer& t, scheduler& sched){
     string linkpath = t.readTraceeCString(traceePtr<char>((char*) t.arg3()), s.traceePid);
     auto inode = inode_from_tracee(linkpath, s.traceePid, gs.log, t.arg2());
     gs.mtimeMap.addRealValue(inode);
+    gs.inodeMap.addRealValue(inode);
   }
 }
 // =======================================================================================
@@ -1559,6 +1564,7 @@ handleDetPost(globalState& gs, state& s, ptracer& t, scheduler& sched){
     string path = t.readTraceeCString(traceePtr<char>((char*) t.arg1()), s.traceePid);
     auto inode = inode_from_tracee(path, s.traceePid, gs.log, -1);
     gs.mtimeMap.addRealValue(inode);
+    gs.inodeMap.addRealValue(inode);
   }
 }
 // =======================================================================================
@@ -1574,6 +1580,7 @@ handleDetPost(globalState& gs, state& s, ptracer& t, scheduler& sched){
     string path = t.readTraceeCString(traceePtr<char>((char*) t.arg2()), s.traceePid);
     auto inode = inode_from_tracee(path, s.traceePid, gs.log, t.arg1());
     gs.mtimeMap.addRealValue(inode);
+    gs.inodeMap.addRealValue(inode);
   }
 }
 // =======================================================================================

--- a/src/utilSystemCalls.cpp
+++ b/src/utilSystemCalls.cpp
@@ -544,7 +544,7 @@ void handlePostOpens(globalState& gs, state& s, ptracer& t, int flags) {
   if(t.getReturnValue() > 0 &&
      // New regular file created through O_CREAT
      (((flags & O_CREAT) == O_CREAT && ! s.fileExisted) ||
-      // Special case for O_TMPFILE
+      // Special case for O_TMPFILE, always consider the file to be newly-created
       ((flags & O_TMPFILE) == O_TMPFILE))
      ){
     gs.log.writeToLog(Importance::info, "A new file was created\n!");


### PR DESCRIPTION
The history is not very clean, sorry about that!

Logging-only changes have already been cherry-picked onto master. The important commits here are 32949f8, 58ec476 and 8ca3797.

On our benchmark of 18 irrepro packages, these patches flip 5 packages from irrepro to repro, and cause no regressions among the others:
https://docs.google.com/spreadsheets/d/1iFQ1w79o672_HiWqjSjYAbtFHrMH-UJ1DCOXqaGPDGU/edit#gid=0
So I think it's ready for merging to master so we can do a large build.