### PR TITLE
Proper CPUID with execve and no brk

### DIFF
--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -343,11 +343,9 @@ void execution::runProgram(){
       log.writeToLog(Importance::inter,
                      log.makeTextColored(Color::blue, "[%d] Caught execve event!\n"),
                      traceesPid);
-
       //reset CPUID trap flag
       states.at(traceesPid).CPUIDTrapSet = false;
 
-  
       handleExecEvent(traceesPid);
       continue;
     }
@@ -557,8 +555,7 @@ bool execution::handleSeccomp(const pid_t traceesPid){
   // Get registers from tracee.
   tracer.updateState(traceesPid);
 
-  if (!states.at(traceesPid).CPUIDTrapSet && !myGlobalState.kernelPre4_12)
-  {
+  if(!states.at(traceesPid).CPUIDTrapSet && !myGlobalState.kernelPre4_12){
     //check if CPUID needs to be set, if it does, set trap
     trapCPUID(myGlobalState, states.at(traceesPid), tracer);
   }
@@ -690,7 +687,7 @@ bool execution::callPreHook(int syscallNumber, globalState& gs,
 
   case SYS_arch_prctl:
     return arch_prctlSystemCall::handleDetPre(gs, s, t, sched);
-    
+
   case SYS_chdir:
     return chdirSystemCall::handleDetPre(gs, s, t, sched);
 
@@ -717,7 +714,7 @@ bool execution::callPreHook(int syscallNumber, globalState& gs,
 
   case SYS_epoll_ctl:
     return epoll_ctlSystemCall::handleDetPre(gs, s, t, sched);
-    
+
   case SYS_execve:
     return execveSystemCall::handleDetPre(gs, s, t, sched);
 
@@ -1007,9 +1004,6 @@ void execution::callPostHook(int syscallNumber, globalState& gs,
 
   case SYS_dup2:
     return dup2SystemCall::handleDetPost(gs, s, t, sched);
-
-  case SYS_execve:
-    return execveSystemCall::handleDetPost(gs, s, t, sched);
 
   case SYS_faccessat:
     return faccessatSystemCall::handleDetPost(gs, s, t, sched);

--- a/src/seccomp.cpp
+++ b/src/seccomp.cpp
@@ -41,7 +41,7 @@ void seccomp::loadRules(bool debug, bool convertUids){
   intercept(SYS_arch_prctl);
   // Change location of the program break.
   noIntercept(SYS_brk);
-  // intercept(SYS_brk);
+
   // Bind seems safe enough to let though, specially since user is stuck in chroot.
   // There might be some slight issues with permission denied if we set up our
   // bind mounts wrong and might need to allow for recursive mounting. But it will


### PR DESCRIPTION
The code on the current master branch for cpuid trapping is wrong. There is no execve post-hook so when we have `noIntercept(SYS_brk)` we get an error that there is no case for SYS_brk (14). This is because instead of going to the execve post-hook we end up at the next system call which happens to be a brk.  I believe between the seccompEvent handler and the arch_prtcl pre-hook we already handle all cases for CPUID trapping, please verify my patch is correct?