### PR TITLE
fixed size for directories in struct stat

### DIFF
--- a/src/utilSystemCalls.cpp
+++ b/src/utilSystemCalls.cpp
@@ -133,7 +133,7 @@ void handleStatFamily(globalState& gs, state& s, ptracer& t, string syscallName)
     // will think we don't have access to this file. Hence we keep our permissions
     // as part of the stat.
     // mode_t    st_mode;        /* File type and mode */
-    gs.log.writeToLog(Importance::info, "st_mode:%u\n", myStat.st_mode);
+    gs.log.writeToLog(Importance::info, "st_mode:0%o\n", myStat.st_mode);
 
     myStat.st_nlink = 1;       /* Number of hard links */
 
@@ -148,7 +148,12 @@ void handleStatFamily(globalState& gs, state& s, ptracer& t, string syscallName)
     // Program will stall if we put some arbitrary value here: TODO.
     // myStat.st_size = 512;        /* Total size, in bytes */
     if (S_ISDIR(myStat.st_mode)) {
-      myStat.st_size = 16384; // force directories to have a fixed size
+      // joe: I haven't seen irreproducible file sizes, but I have seen the same
+      // directory contents result in different sizes across machines (with
+      // different versions of Linux, 4.15 vs 4.18). The same filesystem type
+      // (ext4), same block size, tar --sort=name and --preserve-order weren't
+      // sufficient to determinize the directory st_size.
+      myStat.st_size = 16384;
     }
     gs.log.writeToLog(Importance::info, "st_size:%u\n", myStat.st_size);
 


### PR DESCRIPTION
Force the `struct stat.st_size` field for a directory to always be 16,384B. Using the true size was found to vary from (Broadwell, Ubuntu 18.10) => (Skylake, Ubuntu 18.04) during portability testing for SOSP.

This was found to help resolve portability issues on about a dozen packages, but it's not clear if this will break anything in our larger set of builds.

If the fixed size is too silly, we could in the future make the size a deterministic function of the number of directory entries. I think the size always needs to be a multiple of the filesystem's block size (usually 4KB), so we could take _NumDirectoryEntries * k_ rounded up to the nearest multiple of 4KB, where k is a constant like 128B.