### PR TITLE
Build a statically linked binary in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,17 @@ RUN apt-get update -y && \
     apt-get install -y g++ make strace python3 libseccomp-dev openssh-server fuse libfuse-dev less valgrind
 
 # RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-get update -y
-RUN apt-get install -y software-properties-common clang-6.0 clang++-6.0 lldb-6.0 lld-6.0
+RUN apt-get update -y && \
+    apt-get install -y software-properties-common clang-6.0 clang++-6.0 lldb-6.0 lld-6.0
 
-RUN apt-get update -y
-RUN apt-get install -y pkg-config libarchive-dev libacl1-dev liblzo2-dev liblzma-dev liblz4-dev libbz2-dev libxml2-dev libssl-dev
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libarchive-dev libacl1-dev liblzo2-dev liblzma-dev liblz4-dev libbz2-dev libxml2-dev libssl-dev nettle-dev
 
-RUN apt-get update -y
-RUN apt-get install -y cpio
+RUN apt-get update -y && \
+    apt-get install -y cpio
 
-RUN apt-get update -y
-RUN apt-get install -y libelfin-dev
+RUN apt-get update -y && \
+    apt-get install -y libelfin-dev
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 60 \
 		--slave /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 \
@@ -24,6 +24,6 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 60 \
 
 ADD ./ /detTrace/
 
-RUN cd /detTrace/ && make -j build
+RUN cd /detTrace/ && make -j dynamic-and-static
 
 WORKDIR /detTrace/

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,32 @@
 # Top-level Makefile to capture different actions you can take.
 all: build
 
-build: bin initramfs
-	rm -rf bin/dettrace
-	cd src && ${MAKE}
-	cp src/dettrace bin/
+# Shorthand for `dynamic`.
+build: dynamic
 
 bin:
 	mkdir -p ./bin
 
+# This only builds a dynamically linked binary.
+dynamic: bin initramfs
+	rm -rf bin/dettrace
+	cd src && ${MAKE}
+	cp src/dettrace bin/
+
+# This only builds a statically linked binary.
 static: bin
 	rm -rf bin/dettrace
 	cd src && ${MAKE} all-static
 	cp src/dettrace-static bin/dettrace
+
+# This builds both a dynamically linked binary (named bin/dettrace)
+# and a statically linked binary (named bin/dettrace-static)
+dynamic-and-static: bin initramfs
+	rm -rf bin/dettrace
+	cd src && ${MAKE}
+	cp src/dettrace bin/
+	cd src && ${MAKE} all-static
+	cp src/dettrace-static bin/dettrace-static
 
 templistfile := $(shell mktemp)
 initramfs: initramfs.cpio
@@ -52,7 +66,7 @@ else
 	docker run --rm --privileged --userns=host --cap-add=SYS_ADMIN ${DOCKER_NAME}:${DOCKER_TAG} make -j tests
 endif
 
-.PHONY: clean docker run-docker tests build-tests run-tests initramfs
+.PHONY: build clean docker run-docker tests build-tests run-tests initramfs
 clean:
 	$(RM) bin/dettrace
 	make -C ./src/ clean


### PR DESCRIPTION
Currently, the `Dockerfile` only builds a dynamically linked binary. We now have the need to also produce a statically linked binary with Docker, but it turns out that the `Dockerfile` does not have all of the dependencies it needs to do so. This patch accomplishes this by:

* Adding a dependency on `nettle-dev` to the `Dockerfile`, which is the last missing ingredient needed to successfully build a statically linked `dettrace`. While I was in town, I did some refactoring of how things are `apt-get update && install`'d so that they are more robust.
* I refactored the `Makefile` slightly so that we now have separate `dynamic`, `static`, and `dynamic-and-static` targets, whose names suggest which versions of `dettrace` that they build. The `build` target is now simply an alias for `dynamic`.
* Finally, I tweaked the `Dockerfile` to use `make -j dynamic-and-static` so that it builds both a dynamically linked binary (as `src/dettrace`) and a statically linked binary (as `src/dettrace-static`). As an added bonus, CI will now check that we can successfully build both variants on every commit. Yay!