### PR TITLE
embed initramfs into dettrace binary

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,8 @@ CXXFLAGS =-g -O3 -std=c++14 -Wall $(INCLUDE) $(DEFINES)
 CFLAGS =-g -O3 -Wall -Wshadow $(INCLUDE) $(DEFINES)
 LIBS = -pthread -lseccomp -L ../lib/lib64
 
+INITRAMFS=$(shell ls "../initramfs.cpio")
+
 LIBCRYPTO=$(shell pkg-config --libs libcrypto)
 LIBCRYPTO_STATIC=$(shell pkg-config --static --libs libcrypto)
 
@@ -30,7 +32,10 @@ dep = $(obj:.o=.d)
 all: dettrace
 all-static: dettrace-static
 
-dettrace: $(obj) $(libs)
+initramfs.o: initramfs.S $(INITRAMFS)
+	$(CC) $< $(CFLAGS) -c -o $@ -D__INITRAMFS__='"$(INITRAMFS)"'
+
+dettrace: initramfs.o $(obj) $(libs)
 	$(CXX) $(CXXFLAGS) $^ -o $@ $(LIBS) $(LIBARCHIVE) $(LIBELFIN) $(LIBCRYPTO)
 
 dettrace-static: $(obj) $(libs)
@@ -48,6 +53,7 @@ dettrace-static: $(obj) $(libs)
 clean:
 	$(RM) $(obj)
 	$(RM) $(dep)
+	$(RM) initramfs.o
 	$(RM) dettrace
 # Credits to the awesome makefile guide:
 # http://nuclear.mutantstargoat.com/articles/make/

--- a/src/initramfs.S
+++ b/src/initramfs.S
@@ -1,0 +1,13 @@
+.section .rodata.initramfs
+
+.global __initramfs_start
+__initramfs_start:
+	.incbin __INITRAMFS__
+
+.global __initramfs_end
+__initramfs_end:
+
+.global __initramfs_size
+__initramfs_size:
+	.align 0x8
+	.long __initramfs_end - __initramfs_start


### PR DESCRIPTION
initramfs.cpio is a cpis archive of `root` under `detTrace` directory, it creates lots of headache when packacking `dettrace` binary. This PR embeds `initramfs.cpio` as part of `dettrace` binary, so that the binary alone is sufficient.