### PR TITLE
Change file timestamps from 1970

### DIFF
--- a/include/utilSystemCalls.hpp
+++ b/include/utilSystemCalls.hpp
@@ -7,6 +7,11 @@
 #include "logger.hpp"
 #include "scheduler.hpp"
 #include <optional>
+
+// File creation/mod/access time at container start:
+#define FILE_INITIAL_TIMESTAMP_SECS 946080000
+
+
 /**
  * Compare returned value of system call (rax) vs the blocking value (errnoValue negated),
  * e.g. EAGAIN. If equal, system call would have blocked, log it, preempt current running

--- a/src/dettraceSystemCall.cpp
+++ b/src/dettraceSystemCall.cpp
@@ -2105,8 +2105,8 @@ bool utimeSystemCall::handleDetPre(globalState& gs, state& s, ptracer& t, schedu
   // Create our own struct with our time.
   // TODO: In the future we might want to unify this with our mtimeMapper.
   utimbuf clockTime = {
-    .actime = 0,
-    .modtime = 0,
+    .actime = FILE_INITIAL_TIMESTAMP_SECS,
+    .modtime = FILE_INITIAL_TIMESTAMP_SECS,
   };
 
   // Write our struct to the tracee's memory.
@@ -2143,7 +2143,7 @@ bool utimesSystemCall::handleDetPre(globalState& gs, state& s, ptracer& t, sched
   // Create our own struct with our time.
   // TODO: In the future we might want to unify this with our mtimeMapper.
   timeval clockTime = {
-    .tv_sec = 0,
+    .tv_sec = FILE_INITIAL_TIMESTAMP_SECS,
     .tv_usec = 0,
   };
 
@@ -2190,7 +2190,7 @@ bool utimensatSystemCall::handleDetPre(globalState& gs, state& s, ptracer& t, sc
   // Create our own struct with our time.
   // TODO: In the future we might want to unify this with our mtimeMapper.
   struct timespec clockTime = {
-    .tv_sec = 0,// (time_t) s.getLogicalTime(),
+    .tv_sec = FILE_INITIAL_TIMESTAMP_SECS,  // (time_t) s.getLogicalTime(),
     .tv_nsec = 0, //(time_t) s.getLogicalTime()
   };
 

--- a/src/utilSystemCalls.cpp
+++ b/src/utilSystemCalls.cpp
@@ -105,16 +105,16 @@ void handleStatFamily(globalState& gs, state& s, ptracer& t, string syscallName)
     // Use inode to check if we created this file during our run.
     time_t virtualMtime = gs.mtimeMap.realValueExists(inode) ?
       gs.mtimeMap.getVirtualValue(inode) :
-      0; // This was an old file that has not been opened for modification.
+      FILE_INITIAL_TIMESTAMP_SECS; // This was an old file that has not been opened for modification.
 
     /* Time of last access */
-    myStat.st_atim = timespec { .tv_sec =  0,
+    myStat.st_atim = timespec { .tv_sec =  FILE_INITIAL_TIMESTAMP_SECS,
                                 .tv_nsec = 0 };
     /* Time of last modification */
     myStat.st_mtim = timespec { .tv_sec =  virtualMtime,
                                 .tv_nsec = 0 };
     /* Time of last status change */
-    myStat.st_ctim = timespec { .tv_sec = 0,
+    myStat.st_ctim = timespec { .tv_sec = FILE_INITIAL_TIMESTAMP_SECS,
                                 .tv_nsec = 0 };
 
     // TODO: I'm surprised this doesn't break things. I guess so far, we have only used


### PR DESCRIPTION
Ancient timestamps causes problems with certain software.  Example:

``` File "/usr/lib/python2.7/zipfile.py", line 328, in __init__
    raise ValueError('ZIP does not support timestamps before 1980')```

This first commit just sets it to a different constant, Dec 25 1999.  It also sets the constant atime/ctime as well as mtime.   These are still unchanging, but the floor is set to a different constant.

Before merging this it would be good to open this up to a CLI flag instead of a `#define`d constant...