### PR TITLE
Remove dependency on openssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,12 @@ bin:
 # This only builds a dynamically linked binary.
 dynamic: bin/$(NAME)
 bin/$(NAME): bin $(obj) VERSION
-	$(CXX) $(CXXFLAGS) $(obj) $(LIBS) -o $@ \
-		$(shell pkg-config --libs libcrypto)
+	$(CXX) $(CXXFLAGS) $(obj) $(LIBS) -o $@
 
 # This only builds a statically linked binary.
 static: bin/$(NAME)-static
 bin/$(NAME)-static: bin $(obj)
-	$(CXX) $(CXXFLAGS) -static $(obj) $(LIBS) -o $@ \
-		$(shell pkg-config --static --libs libcrypto)
+	$(CXX) $(CXXFLAGS) -static $(obj) $(LIBS) -o $@
 
 # Compile the source files and generate a dep file at the same time so that
 # incremental builds work (relatively) correctly.


### PR DESCRIPTION
This removes the build dependency on OpenSSL, which is currently only used for calculating SHA1 hashes of bytes during `sys_read` and `sys_write` for logging purposes. I'm unsure how useful this information is in practice, but it does add a moderate complication to the build by depending on OpenSSL. If we want to keep this functionality, I can find a SHA1 implementation and bring it instead of removing this code.