### PR TITLE
[RFC] Add seccomp include dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CC := clang
 CLANG_TIDY := clang-tidy
 
 DEFINES := -D_GNU_SOURCE=1 -D_POSIX_C_SOURCE=20181101 -D__USE_XOPEN=1 -DAPP_VERSION=\"$(DTVERSION)\" -DAPP_BUILDID=\"$(BUILDID)\"
-INCLUDE := -I include -I cxxopts/include
+INCLUDE := -I include -I cxxopts/include -I /usr/include/libseccomp
 CXXFLAGS += -g -O3 -std=c++14 -Wall $(INCLUDE) $(DEFINES)
 CFLAGS += -g -O3 -Wall -Wshadow $(INCLUDE) $(DEFINES)
 LIBS := -pthread -lseccomp


### PR DESCRIPTION
Alternatively use `pkg-config --cflags libseccomp`
to support different OS path layouts