### PR TITLE
intercept getsid system call

### DIFF
--- a/include/dettraceSystemCall.hpp
+++ b/include/dettraceSystemCall.hpp
@@ -576,6 +576,24 @@ public:
 // =======================================================================================
 /**
  *
+ * pid_t getsid(pid_t pid);
+ *
+ * returns a session ID
+ *
+ */
+class getsidSystemCall {
+public:
+  static bool handleDetPre(
+      globalState& gs, state& s, ptracer& t, scheduler& sched);
+  static void handleDetPost(
+      globalState& gs, state& s, ptracer& t, scheduler& sched);
+
+  const int syscallNumber = SYS_getsid;
+  const string syscallName = "getsid";
+};
+// =======================================================================================
+/**
+ *
  * int gettimeofday(struct timeval *tv, struct timezone *tz);
  *
  * gives the number of seconds and microseconds since the Epoch

--- a/src/dettraceSystemCall.cpp
+++ b/src/dettraceSystemCall.cpp
@@ -1024,6 +1024,21 @@ void getrusageSystemCall::handleDetPost(
   return;
 }
 // =======================================================================================
+bool getsidSystemCall::handleDetPre(
+    globalState& gs, state& s, ptracer& t, scheduler& sched) {
+  return true;
+}
+void getsidSystemCall::handleDetPost(
+    globalState& gs, state& s, ptracer& t, scheduler& sched) {
+  // NB: pretend everyone is in their own session
+  pid_t sid = t.getPid();
+  if (0 != t.arg1()) {
+    sid = t.arg1();
+  }
+  t.setReturnRegister(sid);
+  return;
+}
+// =======================================================================================
 bool gettimeofdaySystemCall::handleDetPre(
     globalState& gs, state& s, ptracer& t, scheduler& sched) {
   return true;

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -1110,6 +1110,9 @@ bool execution::callPreHook(
   case SYS_getrusage:
     return getrusageSystemCall::handleDetPre(gs, s, t, sched);
 
+  case SYS_getsid:
+    return getsidSystemCall::handleDetPre(gs, s, t, sched);
+
   case SYS_gettimeofday:
     return gettimeofdaySystemCall::handleDetPre(gs, s, t, sched);
 

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -1453,7 +1453,7 @@ void execution::callPostHook(
 
   case SYS_getsid:
     return getsidSystemCall::handleDetPost(gs, s, t, sched);
-    
+
   case SYS_gettimeofday:
     return gettimeofdaySystemCall::handleDetPost(gs, s, t, sched);
 

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -1451,6 +1451,9 @@ void execution::callPostHook(
   case SYS_getrusage:
     return getrusageSystemCall::handleDetPost(gs, s, t, sched);
 
+  case SYS_getsid:
+    return getsidSystemCall::handleDetPost(gs, s, t, sched);
+    
   case SYS_gettimeofday:
     return gettimeofdaySystemCall::handleDetPost(gs, s, t, sched);
 


### PR DESCRIPTION
The session ID returned by `getsid` is rendered deterministic by always returning the pid for whichever process' session ID was requested.